### PR TITLE
SQ Add fix for the slider being to close to the edge when checked.

### DIFF
--- a/components/atoms/toggle/toggle.scss
+++ b/components/atoms/toggle/toggle.scss
@@ -18,7 +18,7 @@
 
 		&:checked {
 			& + .a-toggle__slider {
-				transform: translateY(-50%) translateX(52px);
+				transform: translateY(-50%) translateX(49px);
 			}
 		}
 	}
@@ -32,7 +32,7 @@
 			input[type=checkbox] {
 				&:checked {
 					& + .a-toggle__slider  {
-						transform: translateY(-50%) translateX(45px);
+						transform: translateY(-50%) translateX(41px);
 					}
 				}
 			}


### PR DESCRIPTION
Quick fix for the toggle slider being to close to the right edge (when checked).
<img width="359" alt="Screenshot 2021-03-09 at 11 50 28" src="https://user-images.githubusercontent.com/62433431/110466471-bc419e00-80cd-11eb-925c-227103d4a208.png">
<img width="352" alt="Screenshot 2021-03-09 at 11 50 35" src="https://user-images.githubusercontent.com/62433431/110466482-bfd52500-80cd-11eb-9c55-c92ffb4cc4f5.png">
